### PR TITLE
Export of blog content type

### DIFF
--- a/config/optional/core.entity_form_display.node.blog.default.yml
+++ b/config/optional/core.entity_form_display.node.blog.default.yml
@@ -1,0 +1,117 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.blog.body
+    - field.field.node.blog.field_if_blog_author
+    - field.field.node.blog.field_if_blog_featured_image
+    - field.field.node.blog.field_if_blog_paragraph
+    - image.style.thumbnail
+    - node.type.blog
+  module:
+    - image
+    - paragraphs
+    - path
+    - text
+id: node.blog.default
+targetEntityType: node
+bundle: blog
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 121
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+    region: content
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_if_blog_author:
+    weight: 123
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_if_blog_featured_image:
+    weight: 124
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  field_if_blog_paragraph:
+    type: entity_reference_paragraphs
+    weight: 122
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+    region: content
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/optional/core.entity_view_display.node.blog.default.yml
+++ b/config/optional/core.entity_view_display.node.blog.default.yml
@@ -1,0 +1,58 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.blog.body
+    - field.field.node.blog.field_if_blog_author
+    - field.field.node.blog.field_if_blog_featured_image
+    - field.field.node.blog.field_if_blog_paragraph
+    - node.type.blog
+  module:
+    - entity_reference_revisions
+    - image
+    - text
+    - user
+id: node.blog.default
+targetEntityType: node
+bundle: blog
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 101
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_if_blog_author:
+    weight: 103
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_if_blog_featured_image:
+    weight: 104
+    label: above
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+  field_if_blog_paragraph:
+    type: entity_reference_revisions_entity_view
+    weight: 102
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/optional/core.entity_view_display.node.blog.teaser.yml
+++ b/config/optional/core.entity_view_display.node.blog.teaser.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.blog.body
+    - field.field.node.blog.field_if_blog_author
+    - field.field.node.blog.field_if_blog_featured_image
+    - field.field.node.blog.field_if_blog_paragraph
+    - node.type.blog
+  module:
+    - text
+    - user
+id: node.blog.teaser
+targetEntityType: node
+bundle: blog
+mode: teaser
+content:
+  body:
+    label: hidden
+    type: text_summary_or_trimmed
+    weight: 101
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_if_blog_author: true
+  field_if_blog_featured_image: true
+  field_if_blog_paragraph: true

--- a/config/optional/core.entity_view_mode.node.teaser.yml
+++ b/config/optional/core.entity_view_mode.node.teaser.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.teaser
+label: Teaser
+targetEntityType: node
+cache: true

--- a/config/optional/field.field.node.blog.body.yml
+++ b/config/optional/field.field.node.blog.body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.blog
+  module:
+    - text
+id: node.blog.body
+field_name: body
+entity_type: node
+bundle: blog
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/config/optional/field.field.node.blog.field_if_blog_author.yml
+++ b/config/optional/field.field.node.blog.field_if_blog_author.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_if_blog_author
+    - node.type.blog
+id: node.blog.field_if_blog_author
+field_name: field_if_blog_author
+entity_type: node
+bundle: blog
+label: Author
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:user'
+  handler_settings:
+    include_anonymous: true
+    filter:
+      type: _none
+    target_bundles: null
+    sort:
+      field: name
+      direction: DESC
+    auto_create: false
+field_type: entity_reference

--- a/config/optional/field.field.node.blog.field_if_blog_featured_image.yml
+++ b/config/optional/field.field.node.blog.field_if_blog_featured_image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_if_blog_featured_image
+    - node.type.blog
+  module:
+    - image
+id: node.blog.field_if_blog_featured_image
+field_name: field_if_blog_featured_image
+entity_type: node
+bundle: blog
+label: 'Featured image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: blog
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: 5MB
+  max_resolution: 2000x2000
+  min_resolution: 480x480
+  alt_field: true
+  alt_field_required: true
+  title_field: true
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/config/optional/field.field.node.blog.field_if_blog_paragraph.yml
+++ b/config/optional/field.field.node.blog.field_if_blog_paragraph.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_if_blog_paragraph
+    - node.type.blog
+  module:
+    - entity_reference_revisions
+id: node.blog.field_if_blog_paragraph
+field_name: field_if_blog_paragraph
+entity_type: node
+bundle: blog
+label: Paragraph
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles: null
+    target_bundles_drag_drop:
+      call_to_action:
+        weight: 9
+        enabled: false
+      colored_text_block_with_image:
+        weight: 10
+        enabled: false
+      cta_content:
+        weight: 11
+        enabled: false
+      expand_collapse:
+        weight: 12
+        enabled: false
+      from_library:
+        weight: 13
+        enabled: false
+      rich_text:
+        weight: 14
+        enabled: false
+      text_with_image_and_header:
+        weight: 15
+        enabled: false
+      two_column_text:
+        weight: 16
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/optional/field.storage.node.body.yml
+++ b/config/optional/field.storage.node.body.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.body
+field_name: body
+entity_type: node
+type: text_with_summary
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: true
+custom_storage: false

--- a/config/optional/field.storage.node.field_if_blog_author.yml
+++ b/config/optional/field.storage.node.field_if_blog_author.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - user
+id: node.field_if_blog_author
+field_name: field_if_blog_author
+entity_type: node
+type: entity_reference
+settings:
+  target_type: user
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/optional/field.storage.node.field_if_blog_featured_image.yml
+++ b/config/optional/field.storage.node.field_if_blog_featured_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+id: node.field_if_blog_featured_image
+field_name: field_if_blog_featured_image
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/optional/field.storage.node.field_if_blog_paragraph.yml
+++ b/config/optional/field.storage.node.field_if_blog_paragraph.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_if_blog_paragraph
+field_name: field_if_blog_paragraph
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/optional/image.style.thumbnail.yml
+++ b/config/optional/image.style.thumbnail.yml
@@ -1,0 +1,14 @@
+langcode: en
+status: true
+dependencies: {  }
+name: thumbnail
+label: 'Thumbnail (100×100)'
+effects:
+  1cfec298-8620-4749-b100-ccb6c4500779:
+    uuid: 1cfec298-8620-4749-b100-ccb6c4500779
+    id: image_scale
+    weight: 0
+    data:
+      width: 100
+      height: 100
+      upscale: false

--- a/config/optional/node.type.blog.yml
+++ b/config/optional/node.type.blog.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: Blog
+type: blog
+description: 'The Blog CT is used for shorter news stories, sometimes with comments enabled, and may have different permissions to allow for students or other, non-standard site editor, users to post.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true


### PR DESCRIPTION
Using drupal console "drupal config:export:content:type" command to export yaml config for install.