### PR TITLE
Enable anchor_link module. Use imagick image processing.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,8 @@
         "drupal/twig_field_value": "^2.0",
         "drupal/twig_tweak": "^2.6",
         "drupal/video_embed_field": "^2.4",
+        "drupal-ckeditor-libraries-group/fakeobjects": "^4.17",
+        "drupal-ckeditor-libraries-group/link": "^4.17",
         "drush/drush": "^10.2",
         "npm-asset/blazy": "~1.0",
         "npm-asset/slick-carousel": "~1.0"

--- a/illinois_framework_core.install
+++ b/illinois_framework_core.install
@@ -1,6 +1,23 @@
 <?php
 
 /**
+ * Implement hook_install().
+ */
+function illinois_framework_core_install() {
+  illinois_framework_core_set_image_processor();
+}
+
+/**
+ * Set the default image handler to imagick
+ */
+function illinois_framework_core_set_image_processor() {
+  $config_factory = \Drupal::configFactory();
+  $system_image_config = $config_factory->getEditable('system.image');
+  $system_image_config->set('toolkit', 'imagick');
+  $system_image_config->save(TRUE);
+}
+
+/**
  * Enable config sync module
  */
 function illinois_framework_core_update_9200() {
@@ -12,4 +29,18 @@ function illinois_framework_core_update_9200() {
  */
 function illinois_framework_core_update_9201() {
   \Drupal::service('module_installer')->install(['advanced_text_formatter']);
+}
+
+/**
+ * Set the default image handler to imagick
+ */
+function illinois_framework_core_update_9203() {
+  illinois_framework_core_set_image_processor();
+}
+
+/**
+ * Set the default image handler to imagick
+ */
+function illinois_framework_core_update_9204() {
+  \Drupal::service('module_installer')->install(['anchor_link']);
 }


### PR DESCRIPTION
Addresses enabling anchor_link module in issue web-illinois/illinois_framework_theme#413 

Also addresses default image processing setting in issue web-illinois/illinois_framework_theme#538