### PR TITLE
Fix site install dependency error

### DIFF
--- a/config/install/field.field.node.content_page.field_paragraph.yml
+++ b/config/install/field.field.node.content_page.field_paragraph.yml
@@ -8,7 +8,6 @@ dependencies:
     - paragraphs.paragraphs_type.bb_content
     - paragraphs.paragraphs_type.cards_content
     - paragraphs.paragraphs_type.contact_content
-    - paragraphs.paragraphs_type.from_library
     - paragraphs.paragraphs_type.icon_row_content
     - paragraphs.paragraphs_type.list_content
     - paragraphs.paragraphs_type.rt_content


### PR DESCRIPTION
Fixes dependency error when installing a new site:

![image](https://user-images.githubusercontent.com/56594946/199559425-3b37f207-a9ea-45a2-a559-1989cf773ef3.png)
