### PR TITLE
Add metatag fields to content pages and news

### DIFF
--- a/config/install/core.entity_form_display.node.content_page.default.yml
+++ b/config/install/core.entity_form_display.node.content_page.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.content_page.body
     - field.field.node.content_page.field_if_meda_featured_image
+    - field.field.node.content_page.field_if_metatags
     - field.field.node.content_page.field_paragraph
     - field.field.node.content_page.field_sidebar
     - field.field.node.content_page.field_sidebar_paragraphs
@@ -12,11 +13,12 @@ dependencies:
     - node.type.content_page
   module:
     - media_library
+    - metatag
     - paragraphs
     - path
     - text
 _core:
-  default_config_hash: gEEdVC8jw9tQ9J_U_LA6WjaM6Ik0zV7s4dZOrtfwJ2k
+  default_config_hash: mx0WuLGwqkgNpyNrzzezkKfVT-x_WIF_Zn_jcs9ldNM
 id: node.content_page.default
 targetEntityType: node
 bundle: content_page
@@ -44,6 +46,14 @@ content:
     region: content
     settings:
       media_types: {  }
+    third_party_settings: {  }
+  field_if_metatags:
+    type: metatag_firehose
+    weight: 26
+    region: content
+    settings:
+      sidebar: true
+      use_details: true
     third_party_settings: {  }
   field_paragraph:
     type: paragraphs

--- a/config/install/core.entity_form_display.node.news.default.yml
+++ b/config/install/core.entity_form_display.node.news.default.yml
@@ -7,6 +7,8 @@ dependencies:
     - field.field.node.news.field_if_author
     - field.field.node.news.field_if_date
     - field.field.node.news.field_if_meda_featured_image
+    - field.field.node.news.field_if_metatags
+    - field.field.node.news.field_if_related_people
     - field.field.node.news.field_if_story_source
     - field.field.node.news.field_if_subtitle
     - field.field.node.news.field_paragraph
@@ -16,9 +18,12 @@ dependencies:
     - datetime
     - link
     - media_library
+    - metatag
     - paragraphs
     - path
     - text
+_core:
+  default_config_hash: q2-l1nwPL8YS6Ioa4WpfjcPLkcnPhSF1kL9PUx82W8k
 id: node.news.default
 targetEntityType: node
 bundle: news
@@ -27,13 +32,13 @@ content:
   body:
     type: text_textarea_with_summary
     weight: 11
+    region: content
     settings:
       rows: 9
       summary_rows: 3
       placeholder: ''
       show_summary: false
     third_party_settings: {  }
-    region: content
   created:
     type: datetime_timestamp
     weight: 5
@@ -41,44 +46,54 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_if_author:
+    type: string_textfield
     weight: 2
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_if_date:
+    type: datetime_default
     weight: 3
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: datetime_default
-    region: content
   field_if_meda_featured_image:
+    type: media_library_widget
     weight: 15
+    region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
-    type: media_library_widget
+  field_if_metatags:
+    type: metatag_firehose
+    weight: 26
     region: content
+    settings:
+      sidebar: true
+      use_details: true
+    third_party_settings: {  }
   field_if_story_source:
+    type: link_default
     weight: 13
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_if_subtitle:
+    type: string_textfield
     weight: 1
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_paragraph:
+    type: paragraphs
     weight: 12
+    region: content
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -93,18 +108,16 @@ content:
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
     third_party_settings: {  }
-    type: paragraphs
-    region: content
   field_tags:
+    type: entity_reference_autocomplete
     weight: 14
+    region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   path:
     type: path
     weight: 8
@@ -113,24 +126,24 @@ content:
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 6
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 10
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 7
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
@@ -143,16 +156,17 @@ content:
   uid:
     type: entity_reference_autocomplete
     weight: 4
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
-    region: content
     third_party_settings: {  }
   url_redirects:
     weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_if_related_people: true

--- a/config/install/core.entity_view_display.node.content_page.default.yml
+++ b/config/install/core.entity_view_display.node.content_page.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.content_page.body
     - field.field.node.content_page.field_if_meda_featured_image
+    - field.field.node.content_page.field_if_metatags
     - field.field.node.content_page.field_paragraph
     - field.field.node.content_page.field_sidebar
     - field.field.node.content_page.field_sidebar_paragraphs
@@ -12,53 +13,61 @@ dependencies:
     - node.type.content_page
   module:
     - entity_reference_revisions
+    - metatag
     - text
     - user
 _core:
-  default_config_hash: LKJVZtpwQ1mhepFP3R71GmgiQUMOgHdqIteZLCDvPJo
+  default_config_hash: cSvSBJvh7XR4EV_2SFh9LxWLfrjHpRlarVquGxBKSnE
 id: node.content_page.default
 targetEntityType: node
 bundle: content_page
 mode: default
 content:
   body:
-    label: hidden
     type: text_default
-    weight: 2
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 2
     region: content
   field_if_meda_featured_image:
     type: entity_reference_entity_view
-    weight: 1
     label: hidden
     settings:
       view_mode: default
       link: false
     third_party_settings: {  }
+    weight: 1
+    region: content
+  field_if_metatags:
+    type: metatag_empty_formatter
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 5
     region: content
   field_paragraph:
-    weight: 3
+    type: entity_reference_revisions_entity_view
     label: hidden
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    type: entity_reference_revisions_entity_view
+    weight: 3
     region: content
   field_tags:
     type: entity_reference_label
-    weight: 4
-    region: content
     label: above
     settings:
       link: true
     third_party_settings: {  }
-  links:
-    weight: 0
+    weight: 4
     region: content
+  links:
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
   field_sidebar: true
   field_sidebar_paragraphs: true

--- a/config/install/core.entity_view_display.node.content_page.teaser.yml
+++ b/config/install/core.entity_view_display.node.content_page.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.content_page.body
     - field.field.node.content_page.field_if_meda_featured_image
+    - field.field.node.content_page.field_if_metatags
     - field.field.node.content_page.field_paragraph
     - field.field.node.content_page.field_sidebar
     - field.field.node.content_page.field_sidebar_paragraphs
@@ -17,38 +18,39 @@ dependencies:
     - user
 third_party_settings:
   layout_builder:
-    allow_custom: false
     enabled: false
+    allow_custom: false
 _core:
-  default_config_hash: 0rxIPJp_r5alzh-CEt0aPK9OQ5eURJqEo35_8cPfIyU
+  default_config_hash: gzP-_srALfLVzZbENN4Kp71ge-LI0D0yxqqVF5FFAIY
 id: node.content_page.teaser
 targetEntityType: node
 bundle: content_page
 mode: teaser
 content:
   body:
-    label: hidden
     type: text_summary_or_trimmed
-    weight: 2
+    label: hidden
     settings:
       trim_length: 200
     third_party_settings: {  }
+    weight: 2
     region: content
   field_if_meda_featured_image:
     type: entity_reference_entity_view
-    weight: 1
     label: hidden
     settings:
       view_mode: default
       link: false
     third_party_settings: {  }
+    weight: 1
     region: content
   links:
-    weight: 0
-    region: content
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
+  field_if_metatags: true
   field_paragraph: true
   field_sidebar: true
   field_sidebar_paragraphs: true

--- a/config/install/core.entity_view_display.node.news.default.yml
+++ b/config/install/core.entity_view_display.node.news.default.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.field.node.news.field_if_author
     - field.field.node.news.field_if_date
     - field.field.node.news.field_if_meda_featured_image
+    - field.field.node.news.field_if_metatags
+    - field.field.node.news.field_if_related_people
     - field.field.node.news.field_if_story_source
     - field.field.node.news.field_if_subtitle
     - field.field.node.news.field_paragraph
@@ -15,86 +17,97 @@ dependencies:
     - datetime
     - entity_reference_revisions
     - link
+    - metatag
     - text
     - user
+_core:
+  default_config_hash: c3XTXCyTjieO1Yqoe-b10sFGdxQ64-IcS00D2tiR3rY
 id: node.news.default
 targetEntityType: node
 bundle: news
 mode: default
 content:
   body:
-    label: hidden
     type: text_default
-    weight: 3
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 3
     region: content
   field_if_author:
-    weight: 6
+    type: string
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 6
     region: content
   field_if_date:
-    weight: 7
+    type: datetime_custom
     label: hidden
     settings:
       timezone_override: ''
       date_format: 'F j, Y'
     third_party_settings: {  }
-    type: datetime_custom
+    weight: 7
     region: content
   field_if_meda_featured_image:
-    weight: 2
+    type: entity_reference_entity_view
     label: hidden
     settings:
       view_mode: default
       link: false
     third_party_settings: {  }
-    type: entity_reference_entity_view
+    weight: 2
+    region: content
+  field_if_metatags:
+    type: metatag_empty_formatter
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 9
     region: content
   field_if_story_source:
-    weight: 8
+    type: link
     label: inline
     settings:
       trim_length: null
-      target: _blank
       url_only: false
       url_plain: false
       rel: '0'
+      target: _blank
     third_party_settings: {  }
-    type: link
+    weight: 8
     region: content
   field_if_subtitle:
-    weight: 0
+    type: string
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 0
     region: content
   field_paragraph:
-    weight: 4
+    type: entity_reference_revisions_entity_view
     label: hidden
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    type: entity_reference_revisions_entity_view
+    weight: 4
     region: content
   field_tags:
-    weight: 5
+    type: entity_reference_label
     label: hidden
     settings:
       link: true
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 5
     region: content
   links:
-    weight: 1
-    region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+    weight: 1
+    region: content
+hidden:
+  field_if_related_people: true

--- a/config/install/core.entity_view_display.node.news.hvrbox_card.yml
+++ b/config/install/core.entity_view_display.node.news.hvrbox_card.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.news.field_if_author
     - field.field.node.news.field_if_date
     - field.field.node.news.field_if_meda_featured_image
+    - field.field.node.news.field_if_metatags
     - field.field.node.news.field_if_related_people
     - field.field.node.news.field_if_story_source
     - field.field.node.news.field_if_subtitle
@@ -25,7 +26,7 @@ third_party_settings:
     enabled: false
     allow_custom: false
 _core:
-  default_config_hash: c3XTXCyTjieO1Yqoe-b10sFGdxQ64-IcS00D2tiR3rY
+  default_config_hash: 69fMV_WBe-7VqplxixfK3ZB40578C0Vy5trj60vQlXc
 id: node.news.hvrbox_card
 targetEntityType: node
 bundle: news
@@ -73,6 +74,7 @@ content:
 hidden:
   field_if_author: true
   field_if_date: true
+  field_if_metatags: true
   field_if_related_people: true
   field_if_story_source: true
   field_if_subtitle: true

--- a/config/install/core.entity_view_display.node.news.teaser.yml
+++ b/config/install/core.entity_view_display.node.news.teaser.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.news.field_if_author
     - field.field.node.news.field_if_date
     - field.field.node.news.field_if_meda_featured_image
+    - field.field.node.news.field_if_metatags
     - field.field.node.news.field_if_related_people
     - field.field.node.news.field_if_story_source
     - field.field.node.news.field_if_subtitle
@@ -19,7 +20,7 @@ dependencies:
     - datetime
     - user
 _core:
-  default_config_hash: eOEeG2LfyBr7TB9q6umoAdHn6QWysWF3HGpX9Ry6214
+  default_config_hash: in5tzT6wnLrH3xE1snc52oGhGVHkX6pvJ5-SMuu5fiY
 id: node.news.teaser
 targetEntityType: node
 bundle: news
@@ -75,6 +76,7 @@ content:
     region: content
 hidden:
   field_if_author: true
+  field_if_metatags: true
   field_if_related_people: true
   field_if_story_source: true
   field_if_subtitle: true

--- a/config/install/field.field.node.content_page.field_if_metatags.yml
+++ b/config/install/field.field.node.content_page.field_if_metatags.yml
@@ -1,0 +1,21 @@
+uuid: a97250fd-c3cd-4abe-a914-f8477b01c27b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_if_metatags
+    - node.type.content_page
+  module:
+    - metatag
+id: node.content_page.field_if_metatags
+field_name: field_if_metatags
+entity_type: node
+bundle: content_page
+label: Metatags
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/config/install/field.field.node.news.field_if_metatags.yml
+++ b/config/install/field.field.node.news.field_if_metatags.yml
@@ -1,0 +1,21 @@
+uuid: d6a5b47b-7420-4e5e-a961-719840920d20
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_if_metatags
+    - node.type.news
+  module:
+    - metatag
+id: node.news.field_if_metatags
+field_name: field_if_metatags
+entity_type: node
+bundle: news
+label: Metatags
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/config/install/field.storage.node.field_if_metatags.yml
+++ b/config/install/field.storage.node.field_if_metatags.yml
@@ -1,0 +1,19 @@
+uuid: 2b42915f-ef57-4477-a559-4a8cf297660b
+langcode: en
+status: true
+dependencies:
+  module:
+    - metatag
+    - node
+id: node.field_if_metatags
+field_name: field_if_metatags
+entity_type: node
+type: metatag
+settings: {  }
+module: metatag
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/metatag.metatag_defaults.global.yml
+++ b/config/install/metatag.metatag_defaults.global.yml
@@ -1,0 +1,11 @@
+uuid: c9332c0d-ac09-49d2-a3e9-27f69e1cb6d1
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: sL588ui1E_8-2c_UupwyYxcqX2OVyMFp3HTLbbFqvPc
+id: global
+label: Global
+tags:
+  canonical_url: '[current-page:url]'
+  title: '[current-page:title] | [site:name]'

--- a/config/install/metatag.metatag_defaults.node.yml
+++ b/config/install/metatag.metatag_defaults.node.yml
@@ -1,0 +1,12 @@
+uuid: 82cfb47c-1277-4096-89d3-b1a761bdec4b
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: rpwvgyEURXLz_JjgMCrkS1rUv-0k3L79BpO-ReN7fDI
+id: node
+label: Content
+tags:
+  title: '[node:title] | [site:name]'
+  description: '[node:summary]'
+  canonical_url: '[node:url]'

--- a/config/install/metatag.metatag_defaults.node__content_page.yml
+++ b/config/install/metatag.metatag_defaults.node__content_page.yml
@@ -1,0 +1,8 @@
+uuid: 5cd2c6ea-aa96-4e07-b62c-c0d908b417b2
+langcode: en
+status: true
+dependencies: {  }
+id: node__content_page
+label: 'Content: Content Page'
+tags:
+  og_image: '[site:url][node:field_if_meda_featured_image:entity:field_media_image]'

--- a/config/install/metatag.metatag_defaults.node__news.yml
+++ b/config/install/metatag.metatag_defaults.node__news.yml
@@ -1,0 +1,8 @@
+uuid: ec12d743-1008-4a4c-8328-3f9ed0e00d4f
+langcode: en
+status: true
+dependencies: {  }
+id: node__news
+label: 'Content: News'
+tags:
+  og_image: '[site:url][node:field_if_meda_featured_image:entity:field_media_image]'

--- a/illinois_framework_core.install
+++ b/illinois_framework_core.install
@@ -89,3 +89,10 @@ function illinois_framework_core_update_9209() {
 function illinois_framework_core_update_9210() {
   \Drupal::service('module_installer')->install(['colorbox']);
 }
+
+/**
+ * Install open graph module
+ */
+function illinois_framework_core_update_9301() {
+  \Drupal::service('module_installer')->install(['metatag_open_graph']);
+}


### PR DESCRIPTION
The featured image field will provide a thumbnail image to the open graph image metatag.

@trubach - can you check this out and test if for me?  I tested it myself and it worked but I'd like to have a second set of eyes on it.  