### PR TITLE
Revert the card background color to prevent config merge issues

### DIFF
--- a/config/install/field.storage.paragraph.field_cards_background.yml
+++ b/config/install/field.storage.paragraph.field_cards_background.yml
@@ -14,10 +14,10 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: il-theme-white
+      value: white
       label: White
     -
-      value: il-theme-blue
+      value: illiniblue
       label: 'Illini Blue'
   allowed_values_function: ''
 module: options


### PR DESCRIPTION
Revert the background color config change in PR #109 in file config/install/field.storage.paragraph.field_cards_background.yml