### PR TITLE
Remove video embed from core

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ The Illinois Framework Core module includes the config to create a predefined se
 - [Redirect](https://www.drupal.org/project/redirect)
 - [Twig Field Value](https://www.drupal.org/project/twig_field_value)
 - [Twig Tweak](https://www.drupal.org/project/twig_tweak)
-- [Video Embed Field](https://www.drupal.org/project/video_embed_field)
 
 # Contributing
 The WIGG Drupal group is welcoming contributions from anyone on campus. Please see the [WIGG Drupal webpage](https://webguidelines.web.illinois.edu/subcommittees/drupal/) for more information.

--- a/composer.json
+++ b/composer.json
@@ -92,11 +92,6 @@
         ],
         "patchLevel": {
             "drupal/core": "-p2"
-        },
-        "patches": {
-            "drupal/video_embed_field": {
-                "3311063 - Add support for Ckeditor 5": "https://www.drupal.org/files/issues/2024-03-13/3311063-56.patch"
-            }
         }
     },
     "repositories": {

--- a/illinois_framework_core.info.yml
+++ b/illinois_framework_core.info.yml
@@ -27,5 +27,3 @@ dependencies:
   - pathauto
   - taxonomy
   - text
-  - video_embed_field
-  - video_embed_wysiwyg

--- a/illinois_framework_core.install
+++ b/illinois_framework_core.install
@@ -96,3 +96,100 @@ function illinois_framework_core_update_9210() {
 function illinois_framework_core_update_9301() {
   \Drupal::service('module_installer')->install(['metatag_open_graph']);
 }
+
+/**
+ * Convert Video Embed WYSIWYG to Video Embed Media
+ */
+function illinois_framework_core_update_9400() {
+  // This code is adapted from https://www.drupal.org/docs/contributed-modules/video-embed-field/migrating-to-core-media#s-when-using-video-embed-wysiwyg
+
+  // Find all formatted text fields on all content entities (Node, Paragraph, etc).
+  $text_long = \Drupal::service('entity_type.manager')->getStorage('field_storage_config')->loadByProperties(['type' => 'text_long']);
+  $text_with_summary = \Drupal::service('entity_type.manager')->getStorage('field_storage_config')->loadByProperties(['type' => 'text_with_summary']);
+  $fields = array_merge($text_long, $text_with_summary);
+  // Iterate through each formatted text field.
+  foreach ($fields as $field) {
+    // Find all entities (e.g. Nodes) that have a video embedded in this field.
+    $ids = \Drupal::entityTypeManager()
+      ->getStorage($field->getTargetEntityTypeId())
+      ->getQuery()
+      ->condition($field->getName(), '%video_url%', 'LIKE')
+      ->accessCheck(FALSE)
+      ->execute();
+    // Iterate through the entities with embedded videos in this field.
+    foreach ($ids as $id) {
+      // Attempt to load the entity.
+      $entity = \Drupal::entityTypeManager()->getStorage($field->getTargetEntityTypeId())->load($id);
+      if ($entity) {
+        // Find the json representing the embedded videos using a regex match.
+        // The regex pattern is taken from the Video Embed WYSIWYG filter plugin.
+        // @see https://git.drupalcode.org/project/video_embed_field/-/blob/8.x-2.x/modules/video_embed_wysiwyg/src/Plugin/Filter/VideoEmbedWysiwyg.php#L133
+        $matches = [];
+        $text = $entity->{$field->getName()}->value;
+        if (!preg_match_all('/(<p>)?(?<json>{(?=.*preview_thumbnail\b)(?=.*settings\b)(?=.*video_url\b)(?=.*settings_summary)(.*)})(<\/p>)?/', $text, $matches)) {
+          continue;
+        }
+        // Iterate through each of the matches. It's possible for a given
+        // entity to have more than one video embedded in a given field.
+        foreach ($matches['json'] as $delta => $match) {
+          // Ensure the JSON string is valid and decode it.
+          $embed_data = json_decode($match, TRUE);
+          if (!$embed_data || !is_array($embed_data)) {
+            continue;
+          }
+          // Extract the embedded video url from the decoded json data.
+          $video_url = $embed_data['video_url'];
+          if (empty($video_url)) {
+            continue;
+          }
+          // Depending on the form of $video_url, you may have to do additional
+          // processing. The following forms for YouTube urls work well:
+          // * https://youtu.be/ABCDEFG1234
+          // * https://www.youtube.com/watch?v=ABCDEFG1234
+          //
+          // However, some other formats are not allowed by Drupal Media such as:
+          // x https://www.youtube.com/embed/ABCDEFG1234
+          //
+          // Just in case, convert from YouTube "embed" url to a "watch" url.
+          // You may have to add more custom processing depending on your source.
+          $video_url = str_replace('youtube.com/embed/', 'youtube.com/watch?v=',$video_url);
+
+          // Check if the $video_url has mediaspace in the domain and set the
+          // bundle to mediaspace_illinois. Otherwise, set the bundle to remote_video.
+          if (strpos($video_url, 'mediaspace.illinois.edu') !== FALSE) {
+            $media = \Drupal::entityTypeManager()->getStorage('media')->create([
+              'bundle' => 'mediaspace_illinois',
+              'field_media_media_remote' => $video_url,
+            ]);
+          }
+          else {
+            $media = \Drupal::entityTypeManager()->getStorage('media')->create([
+              'bundle' => 'remote_video',
+              'field_media_oembed_video' => $video_url,
+            ]);
+          }
+          try {
+            $media->save();
+          }
+          catch (Drupal\Core\Entity\EntityStorageException $e) {
+            \Drupal::logger('video_embed_wysiwyg_update')->error($e->getMessage());
+            continue;
+          }
+          // Build the media embed code. Note that we align everything in the center for simplicity.
+          // If your case is more demanding you can find additional properties on $embed_data.
+          $embed = "<drupal-media data-align=\"center\" data-entity-type=\"media\" data-entity-uuid=\"{$media->uuid()}\"></drupal-media>";
+          // Replace $match with the embed code in $text
+          $text = str_replace($match, $embed, $text);
+          // Save the entity with the updated field value.
+          $entity->{$field->getName()}->setValue([
+            'value' => $text,
+            'format' => $entity->{$field->getName()}->format,
+            'summary' => $entity->{$field->getName()}->summary,
+          ]);
+          $entity->save();
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
The video [embed field module](https://www.drupal.org/project/video_embed_field) does not support CKEditor5. 

This commit adds an update hook that finds all instances of video embedded in the WYSIWYG and replaces it with Drupal's media. Code was used from https://www.drupal.org/docs/contributed-modules/video-embed-field/migrating-to-core-media#s-when-using-video-embed-wysiwyg