### PR TITLE
Update Google Tag manager to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "drupal/extlink": "^1.3",
         "drupal/google_analytics": "^4.0",
         "drupal/google_cse": "^3.1",
-        "drupal/google_tag": "^1.3",
+        "drupal/google_tag": "^2.0",
         "drupal/image_widget_crop": "^2.3",
         "drupal/imagick": "^1.5",
         "drupal/linkit": "^7.0",


### PR DESCRIPTION
Fix for issue #134 - Upgrade google_tag module to 2.x - replacing Google Analytics module