### PR TITLE
Add link to icons for icon fields. Issue #148

### DIFF
--- a/config/install/field.field.paragraph.cta.field_icon_row_content_icon.yml
+++ b/config/install/field.field.paragraph.cta.field_icon_row_content_icon.yml
@@ -11,7 +11,7 @@ field_name: field_icon_row_content_icon
 entity_type: paragraph
 bundle: cta
 label: Icon
-description: ''
+description: '<a href="https://cdn.brand.illinois.edu/icons.html" target="_blank">View examples of all icons</a>'
 required: false
 translatable: false
 default_value: {  }

--- a/config/install/field.field.paragraph.cta.field_icon_row_content_icon.yml
+++ b/config/install/field.field.paragraph.cta.field_icon_row_content_icon.yml
@@ -11,7 +11,7 @@ field_name: field_icon_row_content_icon
 entity_type: paragraph
 bundle: cta
 label: Icon
-description: '<a href="https://cdn.brand.illinois.edu/icons.html" target="_blank">View examples of all icons</a>'
+description: '<a href="https://cdn.brand.illinois.edu/icons.html" target="_blank">View examples of all icons (opens a new tab)</a>'
 required: false
 translatable: false
 default_value: {  }

--- a/config/install/field.field.paragraph.icon_row_content.field_icon_row_content_icon.yml
+++ b/config/install/field.field.paragraph.icon_row_content.field_icon_row_content_icon.yml
@@ -14,7 +14,7 @@ field_name: field_icon_row_content_icon
 entity_type: paragraph
 bundle: icon_row_content
 label: Icon
-description: ''
+description: '<a href="https://cdn.brand.illinois.edu/icons.html" target="_blank">View examples of all icons</a>'
 required: false
 translatable: false
 default_value: {  }

--- a/config/install/field.field.paragraph.icon_row_content.field_icon_row_content_icon.yml
+++ b/config/install/field.field.paragraph.icon_row_content.field_icon_row_content_icon.yml
@@ -14,7 +14,7 @@ field_name: field_icon_row_content_icon
 entity_type: paragraph
 bundle: icon_row_content
 label: Icon
-description: '<a href="https://cdn.brand.illinois.edu/icons.html" target="_blank">View examples of all icons</a>'
+description: '<a href="https://cdn.brand.illinois.edu/icons.html" target="_blank">View examples of all icons (opens a new tab)</a>'
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
Fixes issue #148 - Adds a link to the campus CDN list of icons page for people to reference. 

You can test this by running `drush cd-update` on your environment after checking out the branch.