### PR TITLE
Feature/robgasc/1093 hero design theme update field

### DIFF
--- a/config/install/field.field.paragraph.hero.field_hero_background.yml
+++ b/config/install/field.field.paragraph.hero.field_hero_background.yml
@@ -11,7 +11,7 @@ id: paragraph.hero.field_hero_background
 field_name: field_hero_background
 entity_type: paragraph
 bundle: hero
-label: Design
+label: Theme
 description: ''
 required: true
 translatable: false

--- a/config/install/field.storage.paragraph.field_hero_background.yml
+++ b/config/install/field.storage.paragraph.field_hero_background.yml
@@ -5,6 +5,8 @@ dependencies:
   module:
     - options
     - paragraphs
+_core:
+  default_config_hash: azY0ckDz-EGqCl2Nd9Q9oMoCfoTVVpyxs0f8BmV0YgA
 id: paragraph.field_hero_background
 field_name: field_hero_background
 entity_type: paragraph
@@ -13,22 +15,13 @@ settings:
   allowed_values:
     -
       value: blue
-      label: 'Blue'
+      label: Blue
     -
       value: orange
-      label: 'Orange'
-    -
-      value: image
-      label: 'Image with Blue Background'
-    -
-      value: imageblue
-      label: 'Image with Orange Background'
-    -
-      value: imagewhite
-      label: 'Image with White Background'
+      label: Orange
     -
       value: white
-      label: 'White'
+      label: White
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/install/field.storage.paragraph.field_hero_background.yml
+++ b/config/install/field.storage.paragraph.field_hero_background.yml
@@ -5,8 +5,6 @@ dependencies:
   module:
     - options
     - paragraphs
-_core:
-  default_config_hash: azY0ckDz-EGqCl2Nd9Q9oMoCfoTVVpyxs0f8BmV0YgA
 id: paragraph.field_hero_background
 field_name: field_hero_background
 entity_type: paragraph

--- a/config/install/field.storage.paragraph.field_hero_background.yml
+++ b/config/install/field.storage.paragraph.field_hero_background.yml
@@ -13,10 +13,10 @@ settings:
   allowed_values:
     -
       value: blue
-      label: 'Blue Background'
+      label: 'Blue'
     -
       value: orange
-      label: 'Orange Background'
+      label: 'Orange'
     -
       value: image
       label: 'Image with Blue Background'
@@ -28,7 +28,7 @@ settings:
       label: 'Image with White Background'
     -
       value: white
-      label: 'White Background'
+      label: 'White'
   allowed_values_function: ''
 module: options
 locked: false

--- a/illinois_framework_core.install
+++ b/illinois_framework_core.install
@@ -222,3 +222,37 @@ function illinois_framework_core_update_9700() {
   $editoria11y_config->set('live_h3', '.paragraph-type--cta .ck-editor__editable');
   $editoria11y_config->save(TRUE);
 }
+
+/**
+ * Converts Hero Background field to use only current theme settings from il-hero component
+ */
+function illinois_framework_core_update_10500() {
+  $query = \Drupal::entityQuery('paragraph');
+  $results = $query 
+  ->accessCheck(true)
+  ->condition('field_hero_background', NULL, 'IS NOT NULL')
+  ->execute();
+  foreach ($results as $result) {
+    $paragraph = \Drupal::entityTypeManager()->getStorage('paragraph')->load($result);
+    $background = $paragraph->field_hero_background;
+    $settings = explode(",", $background->getString());
+      switch($settings[0]){  
+        case 'image':
+          $background->set(0, 'blue');
+          \Drupal::messenger()->addMessage("Found image, set to blue");
+          break;
+        case 'imageblue':
+          $background->set(0, 'orange');
+          \Drupal::messenger()->addMessage("Found imageblue, set to orange");
+          break;
+        case 'imagewhite':
+          $background->set(0, 'white');
+          \Drupal::messenger()->addMessage("Found imagewhite, set to white");
+          break;
+        default:
+          \Drupal::messenger()->addMessage($result . ": No matches.");
+        }
+    $paragraph->set('field_hero_background',$background->getString());
+    $paragraph->save();
+  }
+}


### PR DESCRIPTION
This updates the hero design field to be hero theme, and aligns the options to the main ILFW component.

Note, the update hook should be run first with db-update, then the cd-update command following to succeed. If the cd-update is run first, then it will fail and need to be run after the db updates.