### PR TITLE
manually committing a title attribute for mediaspace objects

### DIFF
--- a/templates/media-remote-illinois-mediaspace.html.twig
+++ b/templates/media-remote-illinois-mediaspace.html.twig
@@ -10,5 +10,5 @@
  */
 #}
 <div class="field--name-field-media-oembed-video">
-<iframe  title = "Embedded content from Media Space (https://mediaspace.illinois.edu/)" allowfullscreen="allowfullscreen" src="{{ url }}" width="{{ width }}" height="{{ height }}" frameborder="0"></iframe>
+<iframe title = "Embedded content from Media Space (https://mediaspace.illinois.edu/)" allowfullscreen="allowfullscreen" src="{{ url }}" width="{{ width }}" height="{{ height }}" frameborder="0"></iframe>
 </div>

--- a/templates/media-remote-illinois-mediaspace.html.twig
+++ b/templates/media-remote-illinois-mediaspace.html.twig
@@ -10,5 +10,5 @@
  */
 #}
 <div class="field--name-field-media-oembed-video">
-<iframe allowfullscreen="allowfullscreen" src="{{ url }}" width="{{ width }}" height="{{ height }}" frameborder="0"></iframe>
+<iframe  title = "Embedded content from Media Space (https://mediaspace.illinois.edu/)" allowfullscreen="allowfullscreen" src="{{ url }}" width="{{ width }}" height="{{ height }}" frameborder="0"></iframe>
 </div>

--- a/templates/media-remote-illinois-mediaspace.html.twig
+++ b/templates/media-remote-illinois-mediaspace.html.twig
@@ -10,5 +10,5 @@
  */
 #}
 <div class="field--name-field-media-oembed-video">
-<iframe title = "Embedded content from Media Space (https://mediaspace.illinois.edu/)" allowfullscreen="allowfullscreen" src="{{ url }}" width="{{ width }}" height="{{ height }}" frameborder="0"></iframe>
+<iframe title="Embedded content from Media Space (https://mediaspace.illinois.edu/)" allowfullscreen="allowfullscreen" src="{{ url }}" width="{{ width }}" height="{{ height }}" frameborder="0"></iframe>
 </div>


### PR DESCRIPTION
Added title attribute to the iframe.

<iframe title = "Embedded content from Media Space (https://mediaspace.illinois.edu/)">

Nothing fancy. It prints.