### PR TITLE
updated install file to set gin toolbar on update hook

### DIFF
--- a/illinois_framework_core.install
+++ b/illinois_framework_core.install
@@ -5,6 +5,30 @@
  */
 function illinois_framework_core_install() {
   illinois_framework_core_set_image_processor();
+  illinois_framework_core_configure_toolbar();
+}
+
+/**
+ * Enables toolbar and configures Gin toolbar settings.
+ */
+function illinois_framework_core_configure_toolbar() {
+  // Ensure core toolbar module is enabled.
+  if (!\Drupal::moduleHandler()->moduleExists('toolbar')) {
+    \Drupal::service('module_installer')->install(['toolbar']);
+  }
+
+  // Update Gin configuration.
+  $config = \Drupal::configFactory()->getEditable('gin.settings');
+
+  // Enable classic toolbar.
+  $config->set('classic_toolbar', TRUE);
+
+  // Disable experimental Gin toolbar if present.
+  if ($config->get('enable_gin_toolbar') !== NULL) {
+    $config->set('enable_gin_toolbar', FALSE);
+  }
+
+  $config->save(TRUE);
 }
 
 /**

--- a/illinois_framework_core.install
+++ b/illinois_framework_core.install
@@ -23,11 +23,6 @@ function illinois_framework_core_configure_toolbar() {
   // Enable classic toolbar.
   $config->set('classic_toolbar', 'vertical');
 
-  // Disable experimental Gin toolbar if present.
-  if ($config->get('enable_gin_toolbar') !== NULL) {
-    $config->set('enable_gin_toolbar', FALSE);
-  }
-
   $config->save(TRUE);
 }
 

--- a/illinois_framework_core.install
+++ b/illinois_framework_core.install
@@ -21,7 +21,7 @@ function illinois_framework_core_configure_toolbar() {
   $config = \Drupal::configFactory()->getEditable('gin.settings');
 
   // Enable classic toolbar.
-  $config->set('classic_toolbar', TRUE);
+  $config->set('classic_toolbar', 'vertical');
 
   // Disable experimental Gin toolbar if present.
   if ($config->get('enable_gin_toolbar') !== NULL) {

--- a/illinois_framework_core.install
+++ b/illinois_framework_core.install
@@ -294,3 +294,21 @@ function illinois_framework_core_update_9900() {
     }
   }
 }
+/**
+ * Switch Gin to use the classic (core) toolbar instead of experimental.
+ */
+function illinois_framework_core_update_9951() {
+  // Ensure core toolbar module is enabled.
+  if (!\Drupal::moduleHandler()->moduleExists('toolbar')) {
+    \Drupal::service('module_installer')->install(['toolbar']);
+  }
+  // Update Gin configuration.
+  $config = \Drupal::configFactory()->getEditable('gin.settings');
+  // This is the toolbar setting.
+  $config->set('classic_toolbar', TRUE);
+  // Optional: explicitly disable experimental toolbar if present.
+  if ($config->get('enable_gin_toolbar') !== NULL) {
+    $config->set('enable_gin_toolbar', FALSE);
+  }
+  $config->save(TRUE);
+}

--- a/illinois_framework_core.install
+++ b/illinois_framework_core.install
@@ -322,17 +322,5 @@ function illinois_framework_core_update_9900() {
  * Switch Gin to use the classic (core) toolbar instead of experimental.
  */
 function illinois_framework_core_update_9951() {
-  // Ensure core toolbar module is enabled.
-  if (!\Drupal::moduleHandler()->moduleExists('toolbar')) {
-    \Drupal::service('module_installer')->install(['toolbar']);
-  }
-  // Update Gin configuration.
-  $config = \Drupal::configFactory()->getEditable('gin.settings');
-  // This is the toolbar setting.
-  $config->set('classic_toolbar', TRUE);
-  // Optional: explicitly disable experimental toolbar if present.
-  if ($config->get('enable_gin_toolbar') !== NULL) {
-    $config->set('enable_gin_toolbar', FALSE);
-  }
-  $config->save(TRUE);
+  illinois_framework_core_configure_toolbar();
 }


### PR DESCRIPTION
Solves part of 1139, set gin toolbar.

When running update, sets gin toolbar to be the sane default we provided previously.
4.x only, 5.x WIP.