### PR TITLE
changed label to hidden for paragraph field on default display.

### DIFF
--- a/config/install/core.entity_view_display.node.blog.default.yml
+++ b/config/install/core.entity_view_display.node.blog.default.yml
@@ -63,7 +63,7 @@ content:
     region: content
   field_paragraph:
     type: entity_reference_revisions_entity_view
-    label: above
+    label: hidden
     settings:
       view_mode: default
       link: ''


### PR DESCRIPTION
Solves #154 blog content type - set label to hidden. Hides label in config.