### PR TITLE
Add post update hooks for remove user search page and help search page.

### DIFF
--- a/illinois_framework_core.post_update.php
+++ b/illinois_framework_core.post_update.php
@@ -36,3 +36,31 @@ function illinois_framework_core_post_update_cta_title_optional(&$sandbox) {
     $field_config->save();
   }
 }
+
+/**
+ * Remove the user search page from default Drupal search.
+ */
+function illinois_framework_core_post_update_remove_user_search_page(&$sandbox) {
+  $search_user = \Drupal::configFactory()->getEditable('search.page.user_search');
+
+  if ($search_user) {
+    $search_user->delete();
+    return "Deleted user search page.";
+  } else{
+    return "No user search page found.";
+  }
+}
+
+/**
+ * Remove the help search page from default Drupal search.
+ */
+function illinois_framework_core_post_update_remove_help_search_page(&$sandbox) {
+  $search_help = \Drupal::configFactory()->getEditable('search.page.help_search');
+
+  if ($search_help) {
+    $search_help->delete();
+    return "Deleted help search page.";
+  } else{
+    return "No help search page found.";
+  }
+}


### PR DESCRIPTION
This PR adds post update hooks to remove the user and help search pages. They are config entities but do not have exported config anywhere that I can determine.

Removing them eliminates the "User" tab from the /search page.

It uses post update hooks to complete the action and returns the success state.

1. Login to local copy of the site.
2. Review https://ilfw-dev.lndo.site/admin/config/search/pages and see "User" and "Help" search pages.
3. Run dbupdates.
4. View the page in 2 again.
5. See no user or help search pages.
6. Visit /search
7. See no help or user tab.