### PR TITLE
Update the highlighted news read more link to fix a11y issue

### DIFF
--- a/config/install/views.view.news.yml
+++ b/config/install/views.view.news.yml
@@ -922,7 +922,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<div class=\"highlighted-news-wrapper\">\r\n<div class=\"highlighted-news-content\">\r\n<div class=\"title\"><h2>{{ title }}</h2></div>\r\n<div class=\"body\">{{ body }} <a href=\"{{ view_node }}\" class=\"readmore\">Read full story <span class=\"hidden\">{{ title_1 }}</span></a></div>\r\n</div>\r\n<div class=\"highlighted-news-image\">\r\n{{ field_if_meda_featured_image }}\r\n</div>\r\n</div>"
+            text: "<div class=\"highlighted-news-wrapper\">\r\n<div class=\"highlighted-news-content\">\r\n<div class=\"title\"><h2>{{ title }}</h2></div>\r\n<div class=\"body\">{{ body }} <a href=\"{{ view_node }}\" title=\"Read {{ title_1 }}\" class=\"readmore\">Read&nbsp;full&nbsp;story</a></div>\r\n</div>\r\n<div class=\"highlighted-news-image\">\r\n{{- field_if_meda_featured_image -}}\r\n</div>\r\n</div>"
             make_link: false
             path: ''
             absolute: false
@@ -1928,7 +1928,7 @@ display:
           click_sort_column: value
           type: advanced_text
           settings:
-            trim_length: '400'
+            trim_length: 300
             ellipsis: 1
             word_boundary: 1
             use_summary: 1


### PR DESCRIPTION
This PR updates the highlighted news listing "Read More" link to use the `title` field instead of using a hidden `<span>`. 

It also adds the minus operand to the twig surrounding the the image, so that there will be no whitespace in the image `<div>`. Removing the whitespace allows us to target it with CSS and hide it if it is `:empty`, which is part of the PR web-illinois/illinois_framework_theme#1257

Fixes web-illinois/illinois_framework_theme#1184